### PR TITLE
feat: enable async redis components

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "async-spin-redis"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "spin-sdk",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "http-rust-router-macro",
   "json-http-rust",
   "redis-rust",
+  "redis-rust-async",
   "rust-key-value",
   "rust-outbound-mysql",
   "rust-outbound-pg",

--- a/examples/redis-rust-async/.cargo/config.toml
+++ b/examples/redis-rust-async/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/examples/redis-rust-async/Cargo.toml
+++ b/examples/redis-rust-async/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name    = "async-spin-redis"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = [ "cdylib" ]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# Crate to simplify working with bytes.
+bytes = "1"
+# The Spin SDK.
+spin-sdk = { path = "../.." }

--- a/examples/redis-rust-async/spin.toml
+++ b/examples/redis-rust-async/spin.toml
@@ -1,0 +1,19 @@
+spin_manifest_version = 2
+
+[application]
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "An async redis application."
+name = "async-spin-redis"
+version = "0.1.0"
+
+[application.trigger.redis]
+address = "redis://localhost:6379"
+
+[[trigger.redis]]
+channel = "messages"
+component = "echo-message"
+
+[component.echo-message]
+source = "../target/wasm32-wasi/release/async_spin_redis.wasm"
+[component.echo-message.build]
+command = "cargo build --target wasm32-wasi --release"

--- a/examples/redis-rust-async/src/lib.rs
+++ b/examples/redis-rust-async/src/lib.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use bytes::Bytes;
+use spin_sdk::redis_component;
+use std::str::from_utf8;
+
+/// A simple Spin Redis component.
+#[redis_component]
+async fn on_message(message: Bytes) -> Result<()> {
+    println!("{}", from_utf8(&message)?);
+    Ok(())
+}


### PR DESCRIPTION
This PR implements the ability to mark `#[redis_component]` handlers as `async`. This is motivated by a compelling user story via discord:

> I use Redis' pubsub feature. My spin app's component publishes its message (JSON) to Redis, and the other spin component (worker) subscribes to its message and performs all HTTP requests with the received messages - Thanks to multiple trigger types from Spin 2.2. I was expecting to be able to send lots of HTTP requests simultaneously (asynchronously). However, currently, it is not processing asynchronously. If one request hangs or panics, my worker gets stuck and stops processing altogether. The worker component is stopped, but fortunately, other components are doing their work. 