### PR TITLE
fix relative path in spin.toml of examples

### DIFF
--- a/examples/hello-world/spin.toml
+++ b/examples/hello-world/spin.toml
@@ -11,7 +11,7 @@ route = "/hello"
 component = "hello"
 
 [component.hello]
-source = "../target/wasm32-wasi/release/hello_world.wasm"
+source = "../../target/wasm32-wasi/release/hello_world.wasm"
 description = "A simple component that returns hello."
 [component.hello.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/http-outbound/spin.toml
+++ b/examples/http-outbound/spin.toml
@@ -23,21 +23,25 @@ route = "/hello"
 component = "hello-component"
 
 [component.outbound-http]
-source = "../target/wasm32-wasi/release/http_rust_outbound_http.wasm"
-allowed_outbound_hosts = ["https://random-data-api.fermyon.app", "http://foo.com", "https://foo.com"]
+source = "../../target/wasm32-wasi/release/http_rust_outbound_http.wasm"
+allowed_outbound_hosts = [
+    "https://random-data-api.fermyon.app",
+    "http://foo.com",
+    "https://foo.com",
+]
 [component.outbound-http.build]
 workdir = "outbound-http"
 command = "cargo build --target wasm32-wasi --release"
 
 [component.outbound-http-wildcard]
-source = "../target/wasm32-wasi/release/http_rust_outbound_http.wasm"
+source = "../../target/wasm32-wasi/release/http_rust_outbound_http.wasm"
 allowed_outbound_hosts = ["https://*:*"]
 [component.outbound-http-wildcard.build]
 workdir = "outbound-http"
 command = "cargo build --target wasm32-wasi --release"
 
 [component.outbound-http-to-same-app]
-source = "../target/wasm32-wasi/release/outbound_http_to_same_app.wasm"
+source = "../../target/wasm32-wasi/release/outbound_http_to_same_app.wasm"
 # To make outbound calls to components in the same Spin app, use the special value self.
 allowed_outbound_hosts = ["http://self"]
 [component.outbound-http-to-same-app.build]
@@ -45,7 +49,7 @@ workdir = "outbound-http-to-same-app"
 command = "cargo build --target wasm32-wasi --release"
 
 [component.hello-component]
-source = "../target/wasm32-wasi/release/http_hello.wasm"
+source = "../../target/wasm32-wasi/release/http_hello.wasm"
 description = "A simple component that returns hello."
 [component.hello-component.build]
 workdir = "http-hello"

--- a/examples/http-router-macro/spin.toml
+++ b/examples/http-router-macro/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "route"
 
 [component.route]
-source = "../target/wasm32-wasi/release/http_rust_router_macro.wasm"
+source = "../../target/wasm32-wasi/release/http_rust_router_macro.wasm"
 description = "A component that internally routes HTTP requests."
 [component.route.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/http-router/spin.toml
+++ b/examples/http-router/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "route"
 
 [component.route]
-source = "../target/wasm32-wasi/release/http_rust_router.wasm"
+source = "../../target/wasm32-wasi/release/http_rust_router.wasm"
 description = "A component that internally routes HTTP requests."
 [component.route.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/json-http/spin.toml
+++ b/examples/json-http/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "json-demo"
 
 [component.json-demo]
-source = "../target/wasm32-wasi/release/json_http_rust.wasm"
+source = "../../target/wasm32-wasi/release/json_http_rust.wasm"
 description = "Parses 'name' from the POST body and responds using it."
 [component.json-demo.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/key-value/spin.toml
+++ b/examples/key-value/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "hello"
 
 [component.hello]
-source = "../target/wasm32-wasi/release/rust_key_value.wasm"
+source = "../../target/wasm32-wasi/release/rust_key_value.wasm"
 key_value_stores = ["default"]
 [component.hello.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/mqtt-outbound/spin.toml
+++ b/examples/mqtt-outbound/spin.toml
@@ -12,7 +12,7 @@ component = "outbound-mqtt"
 [component.outbound-mqtt]
 # To test anonymous MQTT authentication, remove the values from MQTT_USERNAME and MQTT_PASSWORD env variables.
 environment = { MQTT_ADDRESS = "mqtt://127.0.0.1:1883?client_id=client001", MQTT_USERNAME = "user", MQTT_PASSWORD = "password", MQTT_KEEP_ALIVE_INTERVAL = "30", MQTT_TOPIC = "telemetry" }
-source = "../target/wasm32-wasi/release/rust_outbound_mqtt.wasm"
+source = "../../target/wasm32-wasi/release/rust_outbound_mqtt.wasm"
 allowed_outbound_hosts = ["mqtt://127.0.0.1:1883"]
 [component.outbound-mqtt.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/mysql/spin.toml
+++ b/examples/mysql/spin.toml
@@ -12,7 +12,7 @@ component = "rust-outbound-mysql"
 
 [component.rust-outbound-mysql]
 environment = { DB_URL = "mysql://spin:spin@127.0.0.1/spin_dev" }
-source = "../target/wasm32-wasi/release/rust_outbound_mysql.wasm"
+source = "../../target/wasm32-wasi/release/rust_outbound_mysql.wasm"
 allowed_outbound_hosts = ["mysql://127.0.0.1"]
 [component.rust-outbound-mysql.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/postgres/spin.toml
+++ b/examples/postgres/spin.toml
@@ -11,7 +11,7 @@ component = "outbound-pg"
 
 [component.outbound-pg]
 environment = { DB_URL = "host=localhost user=postgres dbname=spin_dev" }
-source = "../target/wasm32-wasi/release/rust_outbound_pg.wasm"
+source = "../../target/wasm32-wasi/release/rust_outbound_pg.wasm"
 allowed_outbound_hosts = ["postgres://localhost"]
 [component.outbound-pg.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/redis-async/spin.toml
+++ b/examples/redis-async/spin.toml
@@ -14,6 +14,6 @@ channel = "messages"
 component = "echo-message"
 
 [component.echo-message]
-source = "../target/wasm32-wasi/release/async_spin_redis.wasm"
+source = "../../target/wasm32-wasi/release/async_spin_redis.wasm"
 [component.echo-message.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/redis-outbound/spin.toml
+++ b/examples/redis-outbound/spin.toml
@@ -11,7 +11,7 @@ component = "outbound-redis"
 
 [component.outbound-redis]
 environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379", REDIS_CHANNEL = "messages" }
-source = "../target/wasm32-wasi/release/rust_outbound_redis.wasm"
+source = "../../target/wasm32-wasi/release/rust_outbound_redis.wasm"
 allowed_outbound_hosts = ["redis://127.0.0.1"]
 [component.outbound-redis.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/redis/spin.toml
+++ b/examples/redis/spin.toml
@@ -14,6 +14,6 @@ channel = "messages"
 component = "echo-message"
 
 [component.echo-message]
-source = "../target/wasm32-wasi/release/spinredis.wasm"
+source = "../../target/wasm32-wasi/release/spinredis.wasm"
 [component.echo-message.build]
 command = "cargo build --target wasm32-wasi --release"

--- a/examples/variables/spin.toml
+++ b/examples/variables/spin.toml
@@ -15,7 +15,7 @@ route = "/..."
 component = "spin-variables-rust"
 
 [component.spin-variables-rust]
-source = "../target/wasm32-wasi/release/spin_variables_example.wasm"
+source = "../../target/wasm32-wasi/release/spin_variables_example.wasm"
 [component.spin-variables-rust.variables]
 message = "I'm a {{object}}"
 dotenv = "{{dotenv}}"

--- a/examples/wasi-http-streaming-file/spin.toml
+++ b/examples/wasi-http-streaming-file/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "spin-wasi-http-streaming-file"
 
 [component.spin-wasi-http-streaming-file]
-source = "../target/wasm32-wasi/release/spin_wasi_http_streaming_file.wasm"
-files = [{ source = "..", destination = "/" }]
+source = "../../target/wasm32-wasi/release/spin_wasi_http_streaming_file.wasm"
+files = [{ source = "../..", destination = "/" }]
 [component.spin-wasi-http-streaming-file.build]
 command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/examples/wasi-http-streaming-outgoing-body/spin.toml
+++ b/examples/wasi-http-streaming-outgoing-body/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "wasi-http-async"
 
 [component.wasi-http-async]
-source = "../target/wasm32-wasi/release/wasi_http_rust_streaming_outgoing_body.wasm"
+source = "../../target/wasm32-wasi/release/wasi_http_rust_streaming_outgoing_body.wasm"
 allowed_outbound_hosts = ["http://*:*", "https://*:*"]
 [component.wasi-http-async.build]
 command = "cargo build --target wasm32-wasi --release"


### PR DESCRIPTION
Fix the path to the source `.wasm` files in the `spin.toml`. The examples are added as a workspace and by default the build artifacts are present in the `<project root>/target/wasm32-wasi/release`.