### PR TITLE
build examples

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,31 @@
+name: Build Examples
+
+on:
+  push:
+    branches: ["main", "v*"]
+    tags: ["v*"]
+  pull_request:
+    branches: ["main", "v*"]
+    paths-ignore:
+      - "README.md"
+
+env:
+  RUST_VERSION: "1.73"
+  SPIN_VERSION: ""
+
+jobs:
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "${{ env.RUST_VERSION }}"
+          targets: wasm32-wasi
+      - name: Install Spin
+        uses: fermyon/actions/spin/setup@v1
+      - name: Run build_examples.sh
+        run: |
+          chmod +x scripts/build_examples.sh
+          scripts/build_examples.sh

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+EXAMPLES_DIR="examples"
+
+if [[ ! -d "$EXAMPLES_DIR" ]]; then
+  echo "Directory $EXAMPLES_DIR does not exist."
+  exit 1
+fi
+
+for example in "$EXAMPLES_DIR"/*; do
+  if [[ -d "$example" ]]; then
+    example_name=$(basename "$example")
+    
+    # tells GitHub Action to start a new collapsible log section
+    echo "::group::Building example: $example_name"
+    
+    # cd into example app directory
+    cd "$example" || { echo "Failed to change directory to $example"; continue; }
+    
+    build_output=$(spin build 2>&1)
+    build_status=$?
+    
+    if [[ $build_status -eq 0 ]]; then
+      echo "✅ `$ spin build` succeeded for $example_name"
+    else
+      echo "❌ `$ spin build` failed for $example_name"
+    fi
+    echo "$build_output"
+    
+    echo "::endgroup::"
+    
+    # return to the parent directory
+    cd - >/dev/null
+  fi
+done


### PR DESCRIPTION
Adds script for building examples in example dir. Adds github workflow for building examples for PRs, releases (tags) and merges to main and release branches.