### PR TITLE
fix(examples/postgres-v3): update column name

### DIFF
--- a/examples/postgres-v3/src/lib.rs
+++ b/examples/postgres-v3/src/lib.rs
@@ -126,7 +126,7 @@ fn write(_req: Request<()>) -> Result<Response<String>> {
     let conn = pg3::Connection::open(&address)?;
 
     let sql =
-        "INSERT INTO articletest (title, content, authorname, published) VALUES ('aaa', 'bbb', 'ccc', '2024-01-01')";
+        "INSERT INTO articletest (title, content, authorname, publisheddate) VALUES ('aaa', 'bbb', 'ccc', '2024-01-01')";
     let nrow_executed = conn.execute(sql, &[])?;
 
     println!("nrow_executed: {}", nrow_executed);


### PR DESCRIPTION
When running the [postgres-v3 example](https://github.com/fermyon/spin-rust-sdk/tree/main/examples/postgres-v3), I hit the following error on a request to the `write` endpoint:

```
$ curl -i localhost:3000/write
HTTP/1.1 500 Internal Server Error
transfer-encoding: chunked
date: Tue, 26 Nov 2024 22:41:19 GMT

Error::QueryFailed("Error { kind: Db, cause: Some(DbError { severity: \"ERROR\", parsed_severity: Some(Error), code: SqlState(E42703), message: \"column \\\"published\\\" of relation \\\"articletest\\\" does not exist\", detail: None, hint: None, position: Some(Original(54)), where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some(\"parse_target.c\"), line: Some(1080), routine: Some(\"checkInsertTargets\") }) }")
```

Here I'm guessing it should be `publisheddate`.  Is this correct?