### PR TITLE
chore(*): replace wasm32-wasi target with wasm32-wasip1

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -10,7 +10,7 @@ on:
       - "README.md"
 
 env:
-  RUST_VERSION: "1.73"
+  RUST_VERSION: "1.78"
   SPIN_VERSION: ""
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "${{ env.RUST_VERSION }}"
-          targets: wasm32-wasi
+          targets: wasm32-wasip1
       - name: Install Spin
         uses: fermyon/actions/spin/setup@v1
       - name: Run build_examples.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - "README.md"
  
 env:
-  RUST_VERSION: 1.73
+  RUST_VERSION: 1.78
  
 jobs:
   lint-and-test:
@@ -27,7 +27,7 @@ jobs:
         run: |
           rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt
           rustup default ${{ env.RUST_VERSION }}
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
 
       - name: Lint
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - "v*"
 
 env:
-  RUST_VERSION: 1.73
+  RUST_VERSION: 1.78
 
 jobs:
   crates:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/fermyon/spin-rust-sdk"
-rust-version = "1.73"
+rust-version = "1.78"
 homepage = "https://developer.fermyon.com/spin/v2/rust-components"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ route = "/..."
 component = "hello-world"
 
 [component.hello-world]
-source = "target/wasm32-wasi/release/hello_world.wasm"
+source = "target/wasm32-wasip1/release/hello_world.wasm"
 allowed_outbound_hosts = ["https://random-data-api.fermyon.app"]
 [component.hello-world.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 ```
 
@@ -90,7 +90,7 @@ Spin build can be used to build all components defined in the Spin manifest file
 
 ```bash
 $ spin build --up
-Building component hello-world with `cargo build --target wasm32-wasi --release`
+Building component hello-world with `cargo build --target wasm32-wasip1 --release`
     Finished release [optimized] target(s) in 0.12s
 Finished building all Spin components
 Logging component stdio to ".spin/logs/"

--- a/examples/hello-world/.cargo/config.toml
+++ b/examples/hello-world/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/hello-world/spin.toml
+++ b/examples/hello-world/spin.toml
@@ -11,8 +11,8 @@ route = "/hello"
 component = "hello"
 
 [component.hello]
-source = "../../target/wasm32-wasi/release/hello_world.wasm"
+source = "../../target/wasm32-wasip1/release/hello_world.wasm"
 description = "A simple component that returns hello."
 [component.hello.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/examples/http-outbound/http-hello/.cargo/config.toml
+++ b/examples/http-outbound/http-hello/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/http-outbound/outbound-http-to-same-app/.cargo/config.toml
+++ b/examples/http-outbound/outbound-http-to-same-app/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/http-outbound/outbound-http/.cargo/config.toml
+++ b/examples/http-outbound/outbound-http/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/http-outbound/spin.toml
+++ b/examples/http-outbound/spin.toml
@@ -23,7 +23,7 @@ route = "/hello"
 component = "hello-component"
 
 [component.outbound-http]
-source = "../../target/wasm32-wasi/release/http_rust_outbound_http.wasm"
+source = "../../target/wasm32-wasip1/release/http_rust_outbound_http.wasm"
 allowed_outbound_hosts = [
     "https://random-data-api.fermyon.app",
     "http://foo.com",
@@ -31,26 +31,26 @@ allowed_outbound_hosts = [
 ]
 [component.outbound-http.build]
 workdir = "outbound-http"
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 
 [component.outbound-http-wildcard]
-source = "../../target/wasm32-wasi/release/http_rust_outbound_http.wasm"
+source = "../../target/wasm32-wasip1/release/http_rust_outbound_http.wasm"
 allowed_outbound_hosts = ["https://*:*"]
 [component.outbound-http-wildcard.build]
 workdir = "outbound-http"
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 
 [component.outbound-http-to-same-app]
-source = "../../target/wasm32-wasi/release/outbound_http_to_same_app.wasm"
+source = "../../target/wasm32-wasip1/release/outbound_http_to_same_app.wasm"
 # To make outbound calls to components in the same Spin app, use the special value self.
 allowed_outbound_hosts = ["http://self"]
 [component.outbound-http-to-same-app.build]
 workdir = "outbound-http-to-same-app"
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 
 [component.hello-component]
-source = "../../target/wasm32-wasi/release/http_hello.wasm"
+source = "../../target/wasm32-wasip1/release/http_hello.wasm"
 description = "A simple component that returns hello."
 [component.hello-component.build]
 workdir = "http-hello"
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/http-router-macro/.cargo/config.toml
+++ b/examples/http-router-macro/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/http-router-macro/spin.toml
+++ b/examples/http-router-macro/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "route"
 
 [component.route]
-source = "../../target/wasm32-wasi/release/http_rust_router_macro.wasm"
+source = "../../target/wasm32-wasip1/release/http_rust_router_macro.wasm"
 description = "A component that internally routes HTTP requests."
 [component.route.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml", "spin.toml"]

--- a/examples/http-router/.cargo/config.toml
+++ b/examples/http-router/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/http-router/spin.toml
+++ b/examples/http-router/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "route"
 
 [component.route]
-source = "../../target/wasm32-wasi/release/http_rust_router.wasm"
+source = "../../target/wasm32-wasip1/release/http_rust_router.wasm"
 description = "A component that internally routes HTTP requests."
 [component.route.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml", "spin.toml"]

--- a/examples/json-http/.cargo/config.toml
+++ b/examples/json-http/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/json-http/spin.toml
+++ b/examples/json-http/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "json-demo"
 
 [component.json-demo]
-source = "../../target/wasm32-wasi/release/json_http_rust.wasm"
+source = "../../target/wasm32-wasip1/release/json_http_rust.wasm"
 description = "Parses 'name' from the POST body and responds using it."
 [component.json-demo.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/examples/key-value/.cargo/config.toml
+++ b/examples/key-value/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/key-value/spin.toml
+++ b/examples/key-value/spin.toml
@@ -11,7 +11,7 @@ route = "/..."
 component = "hello"
 
 [component.hello]
-source = "../../target/wasm32-wasi/release/rust_key_value.wasm"
+source = "../../target/wasm32-wasip1/release/rust_key_value.wasm"
 key_value_stores = ["default"]
 [component.hello.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/mqtt-outbound/.cargo/config.toml
+++ b/examples/mqtt-outbound/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/mqtt-outbound/spin.toml
+++ b/examples/mqtt-outbound/spin.toml
@@ -12,7 +12,7 @@ component = "outbound-mqtt"
 [component.outbound-mqtt]
 # To test anonymous MQTT authentication, remove the values from MQTT_USERNAME and MQTT_PASSWORD env variables.
 environment = { MQTT_ADDRESS = "mqtt://127.0.0.1:1883?client_id=client001", MQTT_USERNAME = "user", MQTT_PASSWORD = "password", MQTT_KEEP_ALIVE_INTERVAL = "30", MQTT_TOPIC = "telemetry" }
-source = "../../target/wasm32-wasi/release/rust_outbound_mqtt.wasm"
+source = "../../target/wasm32-wasip1/release/rust_outbound_mqtt.wasm"
 allowed_outbound_hosts = ["mqtt://127.0.0.1:1883"]
 [component.outbound-mqtt.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/mysql/.cargo/config.toml
+++ b/examples/mysql/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/mysql/spin.toml
+++ b/examples/mysql/spin.toml
@@ -12,7 +12,7 @@ component = "rust-outbound-mysql"
 
 [component.rust-outbound-mysql]
 environment = { DB_URL = "mysql://spin:spin@127.0.0.1/spin_dev" }
-source = "../../target/wasm32-wasi/release/rust_outbound_mysql.wasm"
+source = "../../target/wasm32-wasip1/release/rust_outbound_mysql.wasm"
 allowed_outbound_hosts = ["mysql://127.0.0.1"]
 [component.rust-outbound-mysql.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/postgres-v3/.cargo/config.toml
+++ b/examples/postgres-v3/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/postgres-v3/spin.toml
+++ b/examples/postgres-v3/spin.toml
@@ -11,7 +11,7 @@ component = "outbound-pg"
 
 [component.outbound-pg]
 environment = { DB_URL = "host=localhost user=postgres dbname=spin_dev" }
-source = "../../target/wasm32-wasi/release/rust_outbound_pg_v3.wasm"
+source = "../../target/wasm32-wasip1/release/rust_outbound_pg_v3.wasm"
 allowed_outbound_hosts = ["postgres://localhost"]
 [component.outbound-pg.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/postgres/.cargo/config.toml
+++ b/examples/postgres/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/postgres/spin.toml
+++ b/examples/postgres/spin.toml
@@ -11,7 +11,7 @@ component = "outbound-pg"
 
 [component.outbound-pg]
 environment = { DB_URL = "host=localhost user=postgres dbname=spin_dev" }
-source = "../../target/wasm32-wasi/release/rust_outbound_pg.wasm"
+source = "../../target/wasm32-wasip1/release/rust_outbound_pg.wasm"
 allowed_outbound_hosts = ["postgres://localhost"]
 [component.outbound-pg.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/redis-async/.cargo/config.toml
+++ b/examples/redis-async/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/redis-async/spin.toml
+++ b/examples/redis-async/spin.toml
@@ -14,6 +14,6 @@ channel = "messages"
 component = "echo-message"
 
 [component.echo-message]
-source = "../../target/wasm32-wasi/release/async_spin_redis.wasm"
+source = "../../target/wasm32-wasip1/release/async_spin_redis.wasm"
 [component.echo-message.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/redis-outbound/.cargo/config.toml
+++ b/examples/redis-outbound/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/redis-outbound/spin.toml
+++ b/examples/redis-outbound/spin.toml
@@ -11,7 +11,7 @@ component = "outbound-redis"
 
 [component.outbound-redis]
 environment = { REDIS_ADDRESS = "redis://127.0.0.1:6379", REDIS_CHANNEL = "messages" }
-source = "../../target/wasm32-wasi/release/rust_outbound_redis.wasm"
+source = "../../target/wasm32-wasip1/release/rust_outbound_redis.wasm"
 allowed_outbound_hosts = ["redis://127.0.0.1"]
 [component.outbound-redis.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/redis/.cargo/config.toml
+++ b/examples/redis/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/redis/spin.toml
+++ b/examples/redis/spin.toml
@@ -14,6 +14,6 @@ channel = "messages"
 component = "echo-message"
 
 [component.echo-message]
-source = "../../target/wasm32-wasi/release/spinredis.wasm"
+source = "../../target/wasm32-wasip1/release/spinredis.wasm"
 [component.echo-message.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/variables/.cargo/config.toml
+++ b/examples/variables/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/variables/spin.toml
+++ b/examples/variables/spin.toml
@@ -15,9 +15,9 @@ route = "/..."
 component = "spin-variables-rust"
 
 [component.spin-variables-rust]
-source = "../../target/wasm32-wasi/release/spin_variables_example.wasm"
+source = "../../target/wasm32-wasip1/release/spin_variables_example.wasm"
 [component.spin-variables-rust.variables]
 message = "I'm a {{object}}"
 dotenv = "{{dotenv}}"
 [component.spin-variables-rust.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/wasi-http-streaming-file/.cargo/config.toml
+++ b/examples/wasi-http-streaming-file/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/wasi-http-streaming-file/spin.toml
+++ b/examples/wasi-http-streaming-file/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "spin-wasi-http-streaming-file"
 
 [component.spin-wasi-http-streaming-file]
-source = "../../target/wasm32-wasi/release/spin_wasi_http_streaming_file.wasm"
+source = "../../target/wasm32-wasip1/release/spin_wasi_http_streaming_file.wasm"
 files = [{ source = "../..", destination = "/" }]
 [component.spin-wasi-http-streaming-file.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/examples/wasi-http-streaming-file/src/lib.rs
+++ b/examples/wasi-http-streaming-file/src/lib.rs
@@ -23,7 +23,7 @@ async fn stream_file(_req: IncomingRequest, res: ResponseOutparam) -> Result<()>
     let mut body = response.take_body();
     res.set(response);
 
-    let mut file = File::open("target/wasm32-wasi/release/spin_wasi_http_streaming_file.wasm")?;
+    let mut file = File::open("target/wasm32-wasip1/release/spin_wasi_http_streaming_file.wasm")?;
 
     let mut buffer = vec![0; CHUNK_SIZE];
 

--- a/examples/wasi-http-streaming-outgoing-body/.cargo/config.toml
+++ b/examples/wasi-http-streaming-outgoing-body/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"

--- a/examples/wasi-http-streaming-outgoing-body/spin.toml
+++ b/examples/wasi-http-streaming-outgoing-body/spin.toml
@@ -11,8 +11,8 @@ route = "/..."
 component = "wasi-http-async"
 
 [component.wasi-http-async]
-source = "../../target/wasm32-wasi/release/wasi_http_rust_streaming_outgoing_body.wasm"
+source = "../../target/wasm32-wasip1/release/wasi_http_rust_streaming_outgoing_body.wasm"
 allowed_outbound_hosts = ["http://*:*", "https://*:*"]
 [component.wasi-http-async.build]
-command = "cargo build --target wasm32-wasi --release"
+command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]

--- a/src/test.rs
+++ b/src/test.rs
@@ -58,7 +58,7 @@ async fn build_component(name: &str) -> Result<Vec<u8>> {
             assert!(
                 Command::new("cargo")
                     .current_dir("test-cases")
-                    .args(["build", "--workspace", "--target", "wasm32-wasi"])
+                    .args(["build", "--workspace", "--target", "wasm32-wasip1"])
                     .status()
                     .await
                     .unwrap()
@@ -72,7 +72,7 @@ async fn build_component(name: &str) -> Result<Vec<u8>> {
 
     ComponentEncoder::default()
         .validate(true)
-        .module(&fs::read(format!("target/wasm32-wasi/debug/{name}.wasm")).await?)?
+        .module(&fs::read(format!("target/wasm32-wasip1/debug/{name}.wasm")).await?)?
         .adapter("wasi_snapshot_preview1", &fs::read(ADAPTER_PATH).await?)?
         .encode()
 }


### PR DESCRIPTION
- Replaces the wasm32-wasi target with wasm32-wasip1 per https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html#renaming-wasm32-wasi-to-wasm32-wasip1
- Bumps the MSRV to 1.78 to ensure the wasm32-wasip1 target is available