### PR TITLE
ci(release.yml): update to use oidc token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC token exchange (crates-io-auth-action)
     if: github.repository_owner == 'spinframework'
     steps:
       - uses: actions/checkout@v4
@@ -21,17 +23,23 @@ jobs:
           rustup toolchain install ${{ env.RUST_VERSION }}
           rustup default ${{ env.RUST_VERSION }}
 
+      - uses: rust-lang/crates-io-auth-action@v1.0.1
+        id: auth
+
       - name: Publish spin-executor to crates.io
         working-directory: ./crates/executor
-        run: |
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish spin-macro to crates.io
         working-directory: ./crates/macro
-        run: |
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish spin-sdk to crates.io
         working-directory: ./
-        run: |
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
- Update the crate publishing logic to use an [oidc token](https://crates.io/docs/trusted-publishing)

Removes the need for a long-lived crates.io API token