### PR TITLE
ref(release.yml): only use semver tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 on:
   push:
-    branches:
-      - main
-      - "v[0-9]+.[0-9]+"
     tags:
       - "v*"
 
@@ -14,9 +11,7 @@ jobs:
   crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    if: |
-      startsWith(github.ref, 'refs/tags/v') &&
-      github.repository_owner == 'spinframework'
+    if: github.repository_owner == 'spinframework'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
- Removes the branch triggers, reducing to only running when a semver (`v*`) tag is pushed.

I'm guessing the branch triggers were a holdover from when this workflow lived in the main spin repo, when there were associated jobs that would run for those events.