### PR TITLE
Stub out first-time manually published crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,17 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@v1.0.1
         id: auth
 
-      - name: Publish spin-wasip3-http-macro to crates.io
-        working-directory: ./crates/spin-wasip3-http-macro
-        run: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      # - name: Publish spin-wasip3-http-macro to crates.io
+      #   working-directory: ./crates/spin-wasip3-http-macro
+      #   run: cargo publish
+      #   env:
+      #     CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-      - name: Publish spin-wasip3-http to crates.io
-        working-directory: ./crates/spin-wasip3-http
-        run: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}     
+      # - name: Publish spin-wasip3-http to crates.io
+      #   working-directory: ./crates/spin-wasip3-http
+      #   run: cargo publish
+      #   env:
+      #     CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}     
 
       - name: Publish spin-executor to crates.io
         working-directory: ./crates/executor


### PR DESCRIPTION
I jumped the gun here and forgot that trusted publishing requires that new crates are manually published. Stubbing this out for now to get the release wrapped up. Ill follow up with a PR to uncomment them.