### PR TITLE
Bump version for patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "spin-executor"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "futures",
  "once_cell",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "spin-wasip3-http"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "spin-wasip3-http-macro"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ chrono = "0.4.42"
 form_urlencoded = "1.2"
 postgres_range = { version = "0.11.1", optional = true }
 rust_decimal = { version = "1.39.0", default-features = false, optional = true }
-spin-executor = { version = "5.1.0", path = "crates/executor" }
-spin-macro = { version = "5.1.0", path = "crates/macro" }
-spin-wasip3-http = { version = "5.1.0", path = "crates/spin-wasip3-http", optional = true }
-spin-wasip3-http-macro = { version = "5.1.0", path = "crates/spin-wasip3-http-macro", optional = true }
+spin-executor = { version = "5.1.1", path = "crates/executor" }
+spin-macro = { version = "5.1.1", path = "crates/macro" }
+spin-wasip3-http = { version = "5.1.1", path = "crates/spin-wasip3-http", optional = true }
+spin-wasip3-http-macro = { version = "5.1.1", path = "crates/spin-wasip3-http-macro", optional = true }
 thiserror = { workspace = true }
 uuid = { version = "1.18.1", optional = true }
 wit-bindgen = { workspace = true }
@@ -97,7 +97,7 @@ wasmtime-wasi-http = "35.0.0"
 wit-component = "0.235.0"
 
 [workspace.package]
-version = "5.1.0"
+version = "5.1.1"
 authors = ["Spin Framework Maintainers <cncf-spin-maintainers@lists.cncf.io>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Pulls in https://github.com/bytecodealliance/wasi-rs/pull/130 through the latest `wasip3` crate release.