### PR TITLE
Add `time::sleep()` function

### DIFF
--- a/crates/spin-sdk/src/lib.rs
+++ b/crates/spin-sdk/src/lib.rs
@@ -55,6 +55,9 @@ pub mod redis;
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
 pub mod sqlite;
 
+/// Time-related functions.
+pub mod time;
+
 /// Application variable lookup.
 #[cfg(feature = "variables")]
 #[cfg_attr(docsrs, doc(cfg(feature = "variables")))]

--- a/crates/spin-sdk/src/time.rs
+++ b/crates/spin-sdk/src/time.rs
@@ -1,0 +1,7 @@
+use std::time::Duration;
+
+/// Wait until the given [`Duration`] has elapsed.
+pub async fn sleep(duration: Duration) {
+    let duration_ns = duration.as_nanos().try_into().unwrap_or(u64::MAX);
+    crate::wasip3::clocks::monotonic_clock::wait_for(duration_ns).await;
+}

--- a/examples/server-sent-events/src/lib.rs
+++ b/examples/server-sent-events/src/lib.rs
@@ -64,11 +64,6 @@ async fn run_sse_loop_impl(mut tx: Sender<String>) -> anyhow::Result<()> {
             }
         }
 
-        sleep(Duration::from_millis(1000 / PINGS_PER_SECOND)).await;
+        spin_sdk::time::sleep(Duration::from_millis(1000 / PINGS_PER_SECOND)).await;
     }
-}
-
-async fn sleep(duration: Duration) {
-    let duration_ns = duration.as_nanos().try_into().unwrap();
-    spin_sdk::wasip3::clocks::monotonic_clock::wait_for(duration_ns).await;
 }


### PR DESCRIPTION
Joel suggested this wee helper from the SSE sample would be a useful SDK function.

Promoting it to the SDK meant I had to deal with a mismatch between Rust durations and WASI durations, as I could no longer safely `unwrap()` a very long duration to fit it in a `u64` of nanoseconds.  Rather than error, I have clipped the duration to `u64::MAX` nanoseconds.  The difference will be user-visible only for sleeps exceeding 35000 years.  My apologies in advance to whichever Saturnian Ultra-Brain hits this in production in 37026.
